### PR TITLE
Separate log debug into a specific file, not mandatory

### DIFF
--- a/init.go
+++ b/init.go
@@ -15,6 +15,10 @@ import (
 
 var stdoutLog string
 var stderrLog string
+
+// separating debug log into a specific file
+var debugLog string
+
 var debugFlag bool
 var versionFlag bool
 
@@ -28,6 +32,7 @@ var Debug *log.Logger
 func init() {
 	flag.StringVar(&stdoutLog, "l", "", "log file for stdout")
 	flag.StringVar(&stderrLog, "e", "", "log file for stderr")
+	flag.StringVar(&debugLog, "d", "", "log file for debug") // only if want to use debugLog
 	flag.BoolVar(&versionFlag, "version", false, "binary version")
 	flag.BoolVar(&debugFlag, "debug", false, "enable debug logging")
 
@@ -70,7 +75,15 @@ func LogInit() {
 func SetDebug(enabled bool) {
 	if enabled {
 		debugFlag = true
-		Debug = log.New(os.Stdout, "debug:", log.Ldate|log.Ltime|log.Lshortfile)
+		if filename := os.Getenv("Debug_Log"); filename != "" {
+			file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+			if err != nil {
+				log.Fatalln("Failed to open log file :", err)
+			}
+			Debug = log.New(file, "debug:", log.Ldate|log.Ltime|log.Lshortfile)
+		} else {
+			Debug = log.New(os.Stdout, "debug:", log.Ldate|log.Ltime|log.Lshortfile)
+		}
 		Debug.Println("---- debug mode ----")
 	}
 }

--- a/init.go
+++ b/init.go
@@ -1,4 +1,4 @@
-// The logging package provides common functionality as log rotation, conditional debug logging etc.
+// Package logging provides common functionality as log rotation, conditional debug logging etc.
 // To initialize this package, just import it as
 // import "gopkg.in/tokopedia/logging.v1
 package logging

--- a/init.go
+++ b/init.go
@@ -75,7 +75,7 @@ func LogInit() {
 func SetDebug(enabled bool) {
 	if enabled {
 		debugFlag = true
-		if filename := os.Getenv("Debug_Log"); filename != "" {
+		if filename := os.Getenv("DEBUG_LOG"); filename != "" {
 			file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 			if err != nil {
 				log.Fatalln("Failed to open log file :", err)


### PR DESCRIPTION
I want to make this changes for easing monitoring process which is hard to define the log and if we merge access log and debug log the size of log is too big.