### PR TITLE
Added 'SetAppVersion()'

### DIFF
--- a/version.go
+++ b/version.go
@@ -5,3 +5,8 @@ var buildhash string
 func appVersion() string {
 	return buildhash
 }
+
+// SetAppVersion see https://github.com/tokopedia/logging/issues/17
+func SetAppVersion(v string) {
+	buildhash = v
+}


### PR DESCRIPTION
Based on issue #17, we let the user/client define their `buildhash` via `SetAppVersion()`